### PR TITLE
Repro codeowners-validator bug

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 /README.md @test-verify-codeowners/child-team-override
-/LICENSE @test-verify-codeowners/child-team-inherit
+/LICENSE @test-verify-codeowners/child-team-override

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+/README.md @test-verify-codeowners/child-team-override
+/LICENSE @test-verify-codeowners/child-team-inherit

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 /README.md @test-verify-codeowners/child-team-override
-/LICENSE @test-verify-codeowners/child-team-override
+/LICENSE @test-verify-codeowners/child-team-inherit

--- a/.github/workflows/code-owners.yaml
+++ b/.github/workflows/code-owners.yaml
@@ -1,0 +1,24 @@
+name: "Codeowners"
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - '**'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      # checkout the repo
+      - uses: actions/checkout@v2
+
+      # validate its codeowners structure
+      - name: GitHub CODEOWNERS Validator
+        uses: mszostok/codeowners-validator@v0.4.0
+        with:
+          checks: "owners"
+
+          github_access_token: ${{ secrets.CODEOWNERS_VALIDATE_TOKEN }}


### PR DESCRIPTION
Note that the `Codeowners / validate` action has failed. 

When the action ran for a commit that didn't reference `child-team-inherit`, it passed: https://github.com/test-verify-codeowners/owners-bug/pull/1/checks?sha=05aa1b95ff5065be57aea2880450b38108d5946d. But when `child-team-inherit` is specified, it fails: https://github.com/test-verify-codeowners/owners-bug/pull/1/checks?check_run_id=850182355